### PR TITLE
Remove overide of Accounts.urls to bring back the hashbang

### DIFF
--- a/lib/server/pretty-emails.js
+++ b/lib/server/pretty-emails.js
@@ -44,21 +44,6 @@ PrettyEmail = {
     }
 };
 
-/* Override Accounts.urls to remove hashbang from urls */
-
-Accounts.urls.resetPassword = function (token) {
-    return Meteor.absoluteUrl('reset-password/' + token);
-};
-
-Accounts.urls.verifyEmail = function (token) {
-    return Meteor.absoluteUrl('verify-email/' + token);
-};
-
-Accounts.urls.enrollAccount = function (token) {
-    return Meteor.absoluteUrl('enroll-account/' + token);
-};
-
-
 /* Customise meteor email templates */
 
 Accounts.emailTemplates.verifyEmail.html = function (user, verifyEmailUrl) {


### PR DESCRIPTION
It doesn't seem to work without the hashbang in the URLs
